### PR TITLE
Add a parameter to deploy multiple markets at once

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@moonwell-fi/market-deployer",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@moonwell-fi/market-deployer",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "ISC",
       "dependencies": {
         "@moonwell-fi/moonwell.js": "^0.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonwell-fi/market-deployer",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Tools to deploy Moonwell Markets",
   "main": "dist/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,41 +6,91 @@ import { configureMarket } from './configure-market'
 import generateGovProposal from './gov-proposal'
 import DeploymentConfiguration from './types/deployment-configuration'
 import MarketConfiguration from './types/market-configuration'
-import { ProposalData } from '@moonwell-fi/moonwell.js'
+import DeployResult from './types/deploy-result'
+import { Market, ProposalData } from '@moonwell-fi/moonwell.js'
+import ConfigureMarketResult from './types/configure-market-result'
 
 const logLevel: LogLevelDesc = (process.env['MOONWELL_MARKET_DEPLOYER_LOGLEVEL'] as LogLevelDesc) ?? 'info'
 log.setLevel(logLevel)
 
+type InternalDeployResult = {
+  marketConfiguration: MarketConfiguration
+  mTokenDeployResult: DeployResult,
+  configureMarketResult: ConfigureMarketResult,
+  govProposal: ProposalData
+}
+
+type MarketsDeployResult = {
+  // Merged proposal
+  proposal: ProposalData
+
+  // Arrays of results for each market
+  marketConfigurations: Array<MarketConfiguration>
+  mTokenDeployResults: Array<DeployResult>
+  configureMarketResults: Array<ConfigureMarketResult>
+}
+
+// Return a single array of all proposal data.
+const mergeProposals = (govProposals: Array<ProposalData>): ProposalData => {
+  const targets = govProposals.map((govProposal: ProposalData) => { return govProposal.targets })
+  const signatures = govProposals.map((govProposal: ProposalData) => { return govProposal.signatures })
+  const callDatas = govProposals.map((govProposal: ProposalData) => { return govProposal.callDatas })
+  const values = govProposals.map((govProposal: ProposalData) => { return govProposal.values })
+
+  return {
+    targets: targets.reduce((prev, next) => { return [...prev, ...next] }),
+    signatures: signatures.reduce((prev, next) => { return [...prev, ...next] }),
+    callDatas: callDatas.reduce((prev, next) => { return [...prev, ...next] }),
+    values: values.reduce((prev, next) => { return [...prev, ...next] })
+  }
+
+}
+
 /**
  * Deploy a market and perform transactions to wire it.
  * 
+ * @param marketConfigurations A set of market configurations
  * @param deploymentConfiguration The configuration to use for the deploy.
  */
 export const deployAndWireMarket = async (
-  marketConfiguration: MarketConfiguration,
+  marketConfigurations: Array<MarketConfiguration>,
   deploymentConfiguration: DeploymentConfiguration
-) => {
-  // Deploy the token contract
-  const mTokenDeployResult = await deployMTokenContract(marketConfiguration, deploymentConfiguration)
+): Promise<MarketsDeployResult> => {
+  const results: Array<InternalDeployResult> = []
+  for (let i = 0; i < marketConfigurations.length; i++) {
+    const marketConfiguration = marketConfigurations[i]
 
-  // Configure the market
-  const configureMarketResult = await configureMarket(
-    mTokenDeployResult.contractAddress,
-    marketConfiguration,
-    deploymentConfiguration
-  )
-  
-  const govProposal: ProposalData  = await generateGovProposal(
-    mTokenDeployResult.contractAddress,
-    marketConfiguration,
-    deploymentConfiguration
-  )
+    // Deploy the token contract
+    const mTokenDeployResult = await deployMTokenContract(marketConfiguration, deploymentConfiguration)
+
+    // Configure the market
+    const configureMarketResult = await configureMarket(
+      mTokenDeployResult.contractAddress,
+      marketConfiguration,
+      deploymentConfiguration
+    )
+
+    const govProposal: ProposalData = await generateGovProposal(
+      mTokenDeployResult.contractAddress,
+      marketConfiguration,
+      deploymentConfiguration
+    )
+
+    results.push(
+      {
+        marketConfiguration,
+        mTokenDeployResult,
+        configureMarketResult,
+        govProposal
+      }
+    )
+  }
 
   return {
-    marketConfiguration,
-    mTokenDeployResult,
-    configureMarketResult,
-    govProposal
+    proposal: mergeProposals(results.map((result) => { return result.govProposal })),
+    marketConfigurations: results.map((results) => { return results.marketConfiguration }),
+    mTokenDeployResults: results.map((results) => { return results.mTokenDeployResult }),
+    configureMarketResults: results.map((results) => { return results.configureMarketResult }),
   }
 }
 

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -18,7 +18,12 @@ const MIN_REQUIRED_BALANCE = ethers.utils.parseUnits('1')
  * @param moonscanApiUrl A URL for moonscan.
  * @return Configuration to run the deployment. 
  */
-const runPreflightChecks = async (environment: Environment, rpcUrl: string, moonscanApiUrl: string): Promise<DeploymentConfiguration> => {
+const runPreflightChecks = async (
+  environment: Environment,
+  rpcUrl: string,
+  moonscanApiUrl: string,
+  numMarkets: number
+): Promise<DeploymentConfiguration> => {
   printHeader(`Running Pre Deployment Checks`)
 
   // Print network data
@@ -75,7 +80,8 @@ const runPreflightChecks = async (environment: Environment, rpcUrl: string, moon
     environment,
     deployer,
     moonscanApiUrl,
-    requiredConfirmations: REQUIRED_CONFIRMATIONS
+    requiredConfirmations: REQUIRED_CONFIRMATIONS,
+    numMarkets
   }
 }
 export default runPreflightChecks

--- a/src/types/deployment-configuration.ts
+++ b/src/types/deployment-configuration.ts
@@ -14,6 +14,9 @@ type DeploymentConfiguration = {
 
   /** The number of confirmations to use */
   requiredConfirmations: number
+
+  /** The number of markets to deploy. */
+  numMarkets: number
 }
 
 export default DeploymentConfiguration


### PR DESCRIPTION
Tested by deploying 1 market and 2 markets. 

Analog in [proposal-verification](https://github.com/moonwell-fi/proposal-verification/pull/9) which will start working once this release is cut. 

